### PR TITLE
change linkerr-boot.ld

### DIFF
--- a/linkerr-boot.ld
+++ b/linkerr-boot.ld
@@ -31,5 +31,7 @@ SECTIONS {
         . = ALIGN(4);
         __bss_end = ABSOLUTE(.);
     } >wram
+
+    __sidata = LOADADDR(.data);
     __wram_end = ORIGIN(wram) + LENGTH(wram) -1 ;
 }


### PR DESCRIPTION
Since there was no `__sidata' symbol in linkerr-boot.ld and there was a link error, it was fixed. The modified file has been confirmed to work on a real gba device.